### PR TITLE
samtools fastq adjustment

### DIFF
--- a/tools/bwa-mem-aligner/bwa-mem-aligner.nf
+++ b/tools/bwa-mem-aligner/bwa-mem-aligner.nf
@@ -22,7 +22,7 @@
  */
 
 nextflow.preview.dsl=2
-version = '0.1.3.0'
+version = '0.1.4.0'
 
 params.input_bam = "tests/input/?????_?.lane.bam"
 params.aligned_lane_prefix = 'grch38-aligned'

--- a/tools/bwa-mem-aligner/bwa-mem-aligner.py
+++ b/tools/bwa-mem-aligner/bwa-mem-aligner.py
@@ -39,7 +39,7 @@ def main():
 
     sort_qname = 'samtools sort -n -O BAM -@ %s %s ' % (str(args.cpus), args.input_bam)
 
-    bam2fastq = ' samtools fastq -@ %s - ' % (str(args.cpus))
+    bam2fastq = ' samtools fastq -O -F 0x900 -@ %s - ' % (str(args.cpus))
 
     #Command with header
     alignment = ' bwa mem -K 100000000 -Y -t %s -p -R "%s" %s - ' % (str(args.cpus), rg_array[0], args.ref_genome)
@@ -47,29 +47,14 @@ def main():
     # Sort the SAM output by coordinate from bwa and save to BAM file
     sort_coordinate = ' samtools sort -O BAM -@ %s -o %s /dev/stdin' % (str(args.cpus), args.aligned_lane_prefix+"."+os.path.basename(args.input_bam))
 
-    cmd = '|'.join([sort_qname, bam2fastq, alignment, sort_coordinate])
+    cmd = ' | '.join([sort_qname, bam2fastq, alignment, sort_coordinate])
 
-    print('command: %s' % cmd)
-    stdout, stderr, p, success = '', '', None, True
     try:
-        p = subprocess.Popen([cmd],
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
-                             shell=True)
-        stdout, stderr = p.communicate()
+        subprocess.run([cmd], shell=True, check=True)
+
     except Exception as e:
-        print('Execution failed: %s' % e, file=sys.stderr)
-        success = False
+        sys.exit('\nExecution failed: %s' % e)
 
-    if p and p.returncode != 0:
-        print('Execution failed, none zero code returned.', file=sys.stderr)
-        success = False
-
-    print(stdout.decode("utf-8"))
-    print(stderr.decode("utf-8"), file=sys.stderr)
-
-    if not success:
-        sys.exit(p.returncode if p.returncode else 1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- use original quality score (#78 )
- exclude secondary and supplementary alignment (#77)
- use high level `subprocess run`